### PR TITLE
fix: correct target frame index in __getitem__ (regression from 1758335)

### DIFF
--- a/pbdl/dataset.py
+++ b/pbdl/dataset.py
@@ -308,16 +308,16 @@ class Dataset:
 
             if self.crop_size is None:
 
-                target = sim[input_frame_idx]
+                target = sim[target_frame_idx]
 
             else:
 
                 if len(dim_list) == 2:
-                    target = sim[input_frame_idx, :, crop_dim_list[0]:crop_dim_list[0]+self.crop_size,
+                    target = sim[target_frame_idx, :, crop_dim_list[0]:crop_dim_list[0]+self.crop_size,
                                                                                crop_dim_list[1]:crop_dim_list[1]+self.crop_size]
 
                 elif len(dim_list) == 3:
-                    target = sim[input_frame_idx, :, crop_dim_list[0]:crop_dim_list[0]+self.crop_size,
+                    target = sim[target_frame_idx, :, crop_dim_list[0]:crop_dim_list[0]+self.crop_size,
                                                                                crop_dim_list[1]:crop_dim_list[1]+self.crop_size,
                                                                                crop_dim_list[2]:crop_dim_list[2]+self.crop_size]
 


### PR DESCRIPTION
In commit 1758335, the refactor adding crop and 3D support introduced a regression in `Dataset.__getitem__`. In the non-intermediate_time_steps branch, all three target assignments (no-crop, 2D crop, 3D crop) were mistakenly changed from `target_frame_idx` to `input_frame_idx`, causing input and target to always be identical. 

**Fix**: replace `input_frame_idx` with `target_frame_idx` in all three affected lines.